### PR TITLE
Turned off manifest check so program compiles on other machines

### DIFF
--- a/Clock/Clock.csproj
+++ b/Clock/Clock.csproj
@@ -58,7 +58,7 @@
     <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
@@ -101,7 +101,6 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="Clock_TemporaryKey.pfx" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>


### PR DESCRIPTION
Hey Lionel,

This is a pull request (just a simple example, in this case, where I turned off a setting that will prevent the code from compiling/running on other computers). If you approve the PR and merge it with your original code it allow other people to run your _Clock2_.